### PR TITLE
Fix mistake in `#[Sealed]` example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ E.g.
 
 ```php
 
-#[Sealed([Success::class, Failure::class])]
+#[Sealed(Success::class, Failure::class)]
 abstract class Result {} // Result can only be extended by Success or Failure
 
 // OK


### PR DESCRIPTION
Self-explanatory; the attribute uses variadic arguments, not an array.