### PR TITLE
Fix mistake using Builder instead Factory class

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ namespace Bar {
     public function allowed(): void 
     {
       // Code below is OK. Only calling public methods
-      $jane = PersonBuilder::create("Jane");
+      $jane = PersonFactory::create("Jane");
       echo $jane->getName();
     }
   


### PR DESCRIPTION
# 📚 Description

On L88 the `PersonFactory` class is created but in L104 a `PersonBuilder::create()` is used 😃 