### PR TITLE
Configure TestTag to be allowed on a class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ class AnotherClass extends Result {}
 
 ## TestTag
 
-The `#[TestTag]` attribute is an idea borrowed from hardware testing. Methods marked with this attribute are only available to test code.
+The `#[TestTag]` attribute is an idea borrowed from hardware testing. Classes or methods marked with this attribute are only available to test code.
 
 E.g.
 
@@ -440,7 +440,8 @@ class PersonTest
 ```
 
 NOTES:
-- Methods with the`#[TestTag]` MUST have public visibility.
+- Classes with the `#[TestTag]` will have an error when any interaction with the class is done.
+- Methods with the `#[TestTag]` MUST have public visibility.
 - For determining what is "test code" see the relevant plugin. E.g. the [PHPStan extension](https://github.com/DaveLiddament/phpstan-php-language-extensions) can be setup to either:
     - Assume all classes that end `Test` is test code. See [className config option](https://github.com/DaveLiddament/phpstan-php-language-extensions#exclude-checks-on-class-names-ending-with-test).
     - Assume all classes within a given namespace is test code. See [namespace config option](https://github.com/DaveLiddament/phpstan-php-language-extensions#exclude-checks-based-on-test-namespace).

--- a/examples/testTag/testTagOnClass.php
+++ b/examples/testTag/testTagOnClass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TestTagOnConstructor;
+
+use DaveLiddament\PhpLanguageExtensions\TestTag;
+
+#[TestTag]
+class Person
+{
+    public function __construct()
+    {
+    }
+
+    public static function create(): Person // No Error, class can interact with itself
+    {
+        return new Person(); // No Error, class can interact with itself
+    }
+}
+
+class AnotherClass
+{
+    public function newInstance(): Person
+    {
+        return new Person();
+    }
+
+    public function buildPerson(): Person
+    {
+        return Person::create();
+    }
+}

--- a/examples/testTag/testTagOnClass.php
+++ b/examples/testTag/testTagOnClass.php
@@ -21,11 +21,11 @@ class AnotherClass
 {
     public function newInstance(): Person
     {
-        return new Person();
+        return new Person(); // ERROR
     }
 
     public function buildPerson(): Person
     {
-        return Person::create();
+        return Person::create(); // ERROR
     }
 }

--- a/examples/testTag/testTagOnClassIgnoredInTestClass.php
+++ b/examples/testTag/testTagOnClassIgnoredInTestClass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TestTagOnConstructor;
+
+use DaveLiddament\PhpLanguageExtensions\TestTag;
+
+#[TestTag]
+class Person
+{
+    public function __construct()
+    {
+    }
+
+    public static function create(): Person // No Error, class can interact with itself
+    {
+        return new Person(); // No Error, class can interact with itself
+    }
+}
+
+class PersonTest
+{
+    public function newInstance(): Person
+    {
+        return new Person(); // ERROR
+    }
+
+    public function buildPerson(): Person
+    {
+        return Person::create(); // ERROR
+    }
+}

--- a/examples/testTag/testTagOnClassIgnoredInTestClass.php
+++ b/examples/testTag/testTagOnClassIgnoredInTestClass.php
@@ -21,11 +21,11 @@ class PersonTest
 {
     public function newInstance(): Person
     {
-        return new Person(); // ERROR
+        return new Person(); // No Error
     }
 
     public function buildPerson(): Person
     {
-        return Person::create(); // ERROR
+        return Person::create(); // No error
     }
 }

--- a/src/NamespaceVisibility.php
+++ b/src/NamespaceVisibility.php
@@ -8,7 +8,7 @@ namespace DaveLiddament\PhpLanguageExtensions;
 final class NamespaceVisibility
 {
     public function __construct(
-        string $namespace = null,
+        ?string $namespace = null,
         bool $excludeSubNamespaces = false,
     ) {
     }

--- a/src/TestTag.php
+++ b/src/TestTag.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace DaveLiddament\PhpLanguageExtensions;
 
 /**
- * Add the TestTag attribute to a method that should only be called by test code.
- * Attempts to call from non-test code will raise an issue.
+ * Add the TestTag attribute to a class or a method that should only be called by test code.
+ * Attempts to use or call from non-test code will raise an issue.
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 final class TestTag
 {
 }


### PR DESCRIPTION
See https://github.com/DaveLiddament/php-language-extensions/issues/25

Perhaps it is best to wait with merging this one until an implementation in DaveLiddament/phpstan-php-language-extensions.
I'm not sure yet how to prevent false errors on the class itself, is it should be possible to interact with itself.
I'll also update the examples here when the implementation is done.